### PR TITLE
Docker aanpassingen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ COPY dvs-http.wsgi .
 COPY requirements.txt .
 COPY config/dvs-server.yaml config/dvs-server.yaml
 COPY config/http.yaml config/http.yaml
+COPY config/logging.yaml config/logging.yaml
+
+RUN mkdir logs
 
 RUN pip install -r requirements.txt
-RUN pip install gunicorn
 
-CMD [ "gunicorn", "dvs-http" ]
 CMD [ "python", "dvs-daemon.py"]
 
-EXPOSE 8120
-EXPOSE 8140 
+EXPOSE 8120 8140

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -5,10 +5,13 @@ COPY dvs-http.wsgi dvs-http.py
 COPY requirements.txt .
 COPY config/dvs-server.yaml config/dvs-server.yaml
 COPY config/http.yaml config/http.yaml
+COPY config/logging.yaml config/logging.yaml
+
+RUN mkdir logs
 
 RUN pip install -r requirements.txt
 RUN pip install gunicorn
 
-CMD [ "gunicorn", "-b :9000", "dvs-http:application" ]
+CMD [ "gunicorn", "-b", ":9000", "dvs-http:application" ]
 
 EXPOSE 9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  dvs-api:
+    image: dvs-api:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    ports:
+      - 9000:9000/tcp
+  dvs-daemon:
+    image: dvs-daemon:latest
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/dvs-http.wsgi
+++ b/dvs-http.wsgi
@@ -6,7 +6,11 @@ import dvs_util
 import dvs_http_interface
 
 # Load config:
-dvs_http_interface.config = dvs_util.load_config(sys.argv[1])
+configfile = sys.argv[1]
+# Gunicorn ondersteund geen parameters, gebruik dan de standaard config file.
+if 'gunicorn' in sys.argv[0]:
+    configfile = 'config/http.yaml'
+dvs_http_interface.config = dvs_util.load_config(configfile)
 dvs_util.setup_logging(dvs_http_interface.config)
 
 application = bottle.default_app()


### PR DESCRIPTION
Ik heb een paar kleine aanpassingen gedaan:

1. In `Dockerfile` stond 2x een `CMD` regel, maar docker ondersteund er maar 1. In de praktijk werd alleen de 2e CMD uitgevoerd.
2. Ik heb de logging configuratie toegevoegd aan beide Dockerfiles.
3. Kleine syntactische aanpassing in `Dockerfile.api` bij de `CMD` om beter docker conventies te volgen.
4. Ik heb de dvs-http.wsgi file aangepast zodat deze correct gunicorn als http server ondersteund.
5. Ik heb een docker-compose configuratie toegevoegd om de containers makkelijk te kunnen opstarten. Als je docker-compose geïnstalleerd hebt, kan je beide containers opstarten met `docker-compose up`.

Ik hoop dat dit gemerged kan worden, als er nog aanpassingen vereist zijn hoor ik het graag.